### PR TITLE
Accept invalid bytecode output and properly give errors for it

### DIFF
--- a/src/qtum/qtumtransaction.h
+++ b/src/qtum/qtumtransaction.h
@@ -443,7 +443,7 @@ class ContractStatus{
         return ContractStatus(1, "Out of gas", extra);
     }
     static ContractStatus CodeError(std::string extra=""){
-        return ContractStatus(2, "Unhandled exception triggered in execution ", extra);
+        return ContractStatus(2, "Unhandled exception triggered in execution", extra);
     }
     static ContractStatus DoesntExist(std::string extra=""){
         return ContractStatus(3, "Contract does not exist", extra);
@@ -454,6 +454,10 @@ class ContractStatus{
     static ContractStatus ErrorWithCommit(std::string extra=""){
         return ContractStatus(5, "Contract chose to commit state, but returned an error code", extra);
     }
+    static ContractStatus InternalError(std::string extra=""){
+        return ContractStatus(6, "Internal error with contract execution", extra);
+    }
+
 };
 
 struct ContractExecutionResult{

--- a/src/qtum/qtumx86.cpp
+++ b/src/qtum/qtumx86.cpp
@@ -204,7 +204,12 @@ bool QtumHypervisor::initVM(const std::vector<uint8_t> bytecode, const BlockData
         return false;
     }
     map = parseContractData(bytecode.data(), &code, &data, &options);
-    if(bytecode.size() < map->codeSize + map->dataSize + map->optionsSize){
+    
+    //check each field in case of overflow exploit
+    if(bytecode.size() < map->codeSize + map->dataSize + map->optionsSize || 
+        bytecode.size() < map->codeSize ||
+        bytecode.size() < map->dataSize ||
+        bytecode.size() < map->optionsSize){
         LogPrintf("Contract bytecode map indicates more bytes than provided\n");
         LogPrintf("Improperly formed bytecode\n");
         return false;


### PR DESCRIPTION
This adds checking for sane contract map info and will error when insane
The tx will still be accepted into the block, but no execution will occur
and it will be treated similar to an out of gas error with all gas consumed